### PR TITLE
JSON bugs

### DIFF
--- a/agent/config.go
+++ b/agent/config.go
@@ -74,7 +74,6 @@ func (c *NetworkConfig) EndpointBits() uint {
 // If no match is found we assume we are running on host which is not
 // part of the Romana setup and spit error out.
 func (a Agent) identifyCurrentHost() error {
-	log.Printf("Agent: Entering identifyCurrentHost()\n")
 	topologyURL, err := common.GetServiceUrl(a.config.Common.Api.RootServiceUrl, "topology")
 	if err != nil {
 		return agentError(err)
@@ -92,7 +91,6 @@ func (a Agent) identifyCurrentHost() error {
 	dcURL := index.Links.FindByRel("datacenter")
 	dc := common.Datacenter{}
 	err = client.Get(dcURL, &dc)
-	log.Printf("Agent: Received datacenter information with CIDR: %s\n", dc.Cidr)
 	if err != nil {
 		return agentError(err)
 	}

--- a/common/common_test.go
+++ b/common/common_test.go
@@ -41,7 +41,8 @@ func (netif *netIf) SetIP(ip string) error {
 	return nil
 }
 
-func TestMarshaling(t *testing.T) {
+// TestFormMarshaling tests marshaling/unmarshaling to/from HTML form.
+func TestFormMarshaling(t *testing.T) {
 	form := "mac_address=aa:bb:cc:dd:ee:ff&ip_address=10.0.1.4&interface_name=eth0"
 	netIf := &netIf{}
 	m := formMarshaller{}
@@ -66,4 +67,5 @@ func TestMarshaling(t *testing.T) {
 	if formStr != "interface_name=eth0&mac_address=aa:bb:cc:dd:ee:ff&ip_address=10.0.1.4" {
 		t.Fail()
 	}
+
 }

--- a/common/service.go
+++ b/common/service.go
@@ -96,7 +96,7 @@ type HostMessage struct {
 	Name      string `json:"name"`
 	Ip        string `json:"ip"`
 	RomanaIp  string `json:"romana_ip"`
-	AgentPort int    `json:"agentPort"`
+	AgentPort int    `json:"agent_port"`
 	Links     Links  `json:"links"`
 	//    Tor string       `json:"tor"`
 }

--- a/topology/topology_test.go
+++ b/topology/topology_test.go
@@ -43,19 +43,20 @@ type MySuite struct {
 var _ = check.Suite(&MySuite{})
 
 func (s *MySuite) SetUpTest(c *check.C) {
+	myLog(c, "Entering SetUP, services started: ", s.servicesStarted)
 	if !s.servicesStarted {
 		dir, _ := os.Getwd()
-		c.Log("Entering setup in directory", dir)
+		myLog(c, "Entering setup in directory", dir)
 		s.configFile = "../common/testdata/romana.sample.yaml"
 		var err error
 		s.config, err = common.ReadConfig(s.configFile)
 		if err != nil {
 			panic(err)
 		}
-		c.Log("Root configuration: ", s.config.Services["root"].Common.Api.GetHostPort())
+		myLog(c, "Root configuration: ", s.config.Services["root"].Common.Api.GetHostPort())
 		root.Run(s.configFile)
 		s.rootUrl = "http://" + s.config.Services["root"].Common.Api.GetHostPort()
-		c.Log("Root URL:", s.rootUrl)
+		myLog(c, "Root URL:", s.rootUrl)
 
 		// Starting root service
 		fmt.Println("Starting root service...")
@@ -64,9 +65,9 @@ func (s *MySuite) SetUpTest(c *check.C) {
 			c.Error(err)
 		}
 		msg := <-channelRoot
-		c.Log("Root service said:", msg)
+		myLog(c, "Root service said:", msg)
 
-		c.Log("Creating topology schema")
+		myLog(c,"Creating topology schema")
 		err = CreateSchema(s.rootUrl, true)
 		myLog(c, "CreateSchema returned err: ", err, "which is of type", reflect.TypeOf(err), "let's compare it to", nil, ": err != nil: ", err != nil)
 		if err != nil {
@@ -82,7 +83,9 @@ func myLog(c *check.C, args ...interface{}) {
 	c.Log(args)
 }
 
-func (s *MySuite) TestMarshaling(c *check.C) {
+// TestHostMarshaling tests marshaling/unmarshaling of Host
+// structure to/from proper JSON.
+func (s *MySuite) TestHostMarshaling(c *check.C) {
 	host := Host{}
 	host.Id = 1
 	host.RomanaIp = "192.168.0.1/16"
@@ -108,7 +111,6 @@ func (s *MySuite) TestMarshaling(c *check.C) {
 
 // Test the topology service
 func (s *MySuite) TestTopology(c *check.C) {
-	return
 	myLog(c, "Entering TestTopology()")
 
 	dir, _ := os.Getwd()


### PR DESCRIPTION
1. agentPort field in a struct was missing a json tag, as a result it required agentPort, not agent_port (which is more JSONy)
2. Added a test for that
3. Fixed up some more json tags.
