### PR TITLE
Seq should not be overwritten. Removed unused Tenant field.

### DIFF
--- a/tenant/mysql.go
+++ b/tenant/mysql.go
@@ -91,6 +91,7 @@ func (mysqlStore *mysqlStore) connect() error {
 	if err != nil {
 		return err
 	}
+	db.LogMode(true)
 	mysqlStore.db = &db
 	return nil
 }
@@ -158,7 +159,6 @@ func (mysqlStore *mysqlStore) findTenant(id uint64) (Tenant, error) {
 	}
 	for i := range tenants {
 		if tenants[i].Id == id {
-			tenants[i].Seq = uint64(i)
 			return tenants[i], nil
 		}
 	}
@@ -213,7 +213,6 @@ func (mysqlStore *mysqlStore) findSegment(tenantId uint64, id uint64) (Segment, 
 	}
 	for i := range segments {
 		if segments[i].Id == id {
-			segments[i].Seq = uint64(i)
 			return segments[i], nil
 		}
 	}

--- a/tenant/store.go
+++ b/tenant/store.go
@@ -45,7 +45,6 @@ type Tenant struct {
 
 type Segment struct {
 	Id       uint64 `sql:"AUTO_INCREMENT"`
-	Tenant   Tenant
 	TenantId uint64
 	Name     string
 	Seq      uint64


### PR DESCRIPTION
Tenant is returning not-useful data to IPAM when querying /tenants/X/segments.
IPAM then uses this data in its IP allocation, generating an unsegmented address.
This fixes the tenant side of things.
IPAM could be updated to be more intelligent.
