### PR TITLE
Fixed shadowed i variable used as slice index

### DIFF
--- a/ipam/ipam.go
+++ b/ipam/ipam.go
@@ -149,7 +149,7 @@ func (ipam *IPAMSvc) legacyAllocateIpByName(input interface{}, ctx common.RestCo
 	for _, s := range segments {
 		if s.Name == segmentName {
 			found = true
-			vm.SegmentId = fmt.Sprintf("%d", tenants[i].Id)
+			vm.SegmentId = fmt.Sprintf("%d", s.Id)
 			break
 		}
 	}


### PR DESCRIPTION
While testing romana installation, this problem was discovered when a tenant has many segments and we try to use one.

IPAM would crash on line 152:           vm.SegmentId = fmt.Sprintf("%d", tenants[i].Id) 
This is because the i variable is shadowed within the loop, and doesn't refer to the intended 'i' variable (tenant's index).

This change addresses that problem.
