### PR TITLE
Allocate address using network IP instead of plain IP from CIDR

### DIFF
--- a/agent/helpers.go
+++ b/agent/helpers.go
@@ -235,24 +235,23 @@ func (h Helper) ensureInterHostRoutes() error {
 	otherHosts := h.otherHosts()
 	via := "via"
 	for j := range otherHosts {
-		romanaIP, romanaCidr, err := net.ParseCIDR(otherHosts[j].RomanaIp)
+		_, romanaCidr, err := net.ParseCIDR(otherHosts[j].RomanaIp)
 		if err != nil {
 			return failedToParseOtherHosts(otherHosts[j].RomanaIp)
 		}
-		//		romanaIP := romanaIP
 		romanaMaskInt, _ := romanaCidr.Mask.Size()
 		romanaMask := fmt.Sprintf("%d", romanaMaskInt)
 		dest := otherHosts[j].Ip
 
 		// wait until no one messing with routes
 		// If route doesn't exist yet
-		if err := h.isRouteExist(romanaIP, romanaMask); err != nil {
+		if err := h.isRouteExist(romanaCidr.IP, romanaMask); err != nil {
 
 			// Create it
-			if err := h.createRoute(romanaIP, romanaMask, via, dest); err != nil {
+			if err := h.createRoute(romanaCidr.IP, romanaMask, via, dest); err != nil {
 
 				// Or report error
-				return routeCreateError(err, romanaIP.String(), romanaMask, dest)
+				return routeCreateError(err, romanaCidr.IP.String(), romanaMask, dest)
 			}
 		}
 	}

--- a/common/structures.go
+++ b/common/structures.go
@@ -30,7 +30,14 @@ func MakeIPv4(a, b, c, d byte) IP {
 }
 
 func IPv4ToInt(ip net.IP) uint64 {
-	return uint64(ip[12])<<24 | uint64(ip[13])<<16 | uint64(ip[14])<<8 | uint64(ip[15])
+	switch len(ip) {
+	case 4: // IPv4
+		return uint64(ip[0])<<24 | uint64(ip[1])<<16 | uint64(ip[2])<<8 | uint64(ip[3])
+	case 16: // IPv6
+		return uint64(ip[12])<<24 | uint64(ip[13])<<16 | uint64(ip[14])<<8 | uint64(ip[15])
+	default:
+		return 0
+	}
 }
 
 func IntToIPv4(ipInt uint64) net.IP {

--- a/ipam/ipam.go
+++ b/ipam/ipam.go
@@ -226,11 +226,11 @@ func (ipam *IPAMSvc) addVm(input interface{}, ctx common.RestContext) (interface
 	tenantBitShift := segmentBitShift + ipam.dc.SegmentBits
 	//	hostBitShift := tenantBitShift + ipam.dc.TenantBits
 	log.Printf("Parsing Romana IP address of host %s: %s\n", host.Name, host.RomanaIp)
-	hostIp, _, err := net.ParseCIDR(host.RomanaIp)
+	_, network, err := net.ParseCIDR(host.RomanaIp)
 	if err != nil {
 		return nil, err
 	}
-	hostIpInt := common.IPv4ToInt(hostIp)
+	hostIpInt := common.IPv4ToInt(network.IP)
 	vmIpInt := (ipam.dc.Prefix << prefixBitShift) | hostIpInt | (t.Seq << tenantBitShift) | (segment.Seq << segmentBitShift) | vm.EffectiveSeq
 	vmIpIp := common.IntToIPv4(vmIpInt)
 	log.Printf("Constructing (%d << %d) | %d | (%d << %d) | ( %d << %d ) | %d=%s\n", ipam.dc.Prefix, prefixBitShift, hostIpInt, t.Seq, tenantBitShift, segment.Seq, segmentBitShift, vm.EffectiveSeq, vmIpIp.String())


### PR DESCRIPTION
Before: romana_ip needs to be configured as network address (10.1.0.**0**/16) instead of IP and mask (10.1.0.**1**/16)
Using a .1 address in this config would make IPAM allocate only even addresses. (It would take the full address 10.1.0.**1** and add tenant/segment bits, instead of taking the network address 10.1.0.**0**).
After: always calculate off network address.

Impact: k8s-listener is using romana_ip when it detects a new policy and tries to send instructions to the listener-agent to create rules.