### PR TITLE
Should operate on network address

### DIFF
--- a/agent/helpers.go
+++ b/agent/helpers.go
@@ -215,7 +215,7 @@ func (h Helper) ensureInterHostRoutes() error {
 
 	via := "via"
 	for _, host := range h.Agent.networkConfig.otherHosts {
-		romanaIP, romanaCidr, err := net.ParseCIDR(host.RomanaIp)
+		_, romanaCidr, err := net.ParseCIDR(host.RomanaIp)
 		if err != nil {
 			return failedToParseOtherHosts(host.RomanaIp)
 		}
@@ -228,9 +228,9 @@ func (h Helper) ensureInterHostRoutes() error {
 		if err := h.isRouteExist(romanaCidr.IP, romanaMask); err != nil {
 
 			// Create it
-			err := h.createRoute(romanaIP, romanaMask, via, dest)
+			err := h.createRoute(romanaCidr.IP, romanaMask, via, dest)
 			if err != nil {
-				return routeCreateError(err, romanaIP.String(), romanaMask, dest)
+				return routeCreateError(err, romanaCidr.IP.String(), romanaMask, dest)
 			}
 		}
 	}


### PR DESCRIPTION
Experiencing this error on master:
```
2016/03/06 21:53:26 Token created 5c09a708-f9ed-4b85-8ca5-1156453a6254
2016/03/06 21:53:26 Agent: Entering k8sPodUpHandler()
2016/03/06 21:53:26 Agent: Got request for network configuration: &{{veth0-11957 de:ad:be:ef:00:00 10.0.19.3} map[namespace_isolation:off]}
2016/03/06 21:53:26 Agent: Entering k8sPodUpHandle()
2016/03/06 21:53:26 Isolation is false
2016/03/06 21:53:26 Helper: Waiting for interface veth0-11957, 0 attempt
2016/03/06 21:53:26 Agent: ensuring interhost routes exist
2016/03/06 21:53:26 Acquiring mutex ensureInterhostRoutes
2016/03/06 21:53:26 Acquired mutex ensureInterhostRoutes
2016/03/06 21:53:26 Helper.Executor: executing command: /sbin/ip ro show 10.1.0.0/16
2016/03/06 21:53:26 Helper: creating route
2016/03/06 21:53:26 Helper.Executor: executing command: /sbin/ip ro add 10.1.0.1/16 via 192.168.99.11
2016/03/06 21:53:26 Releasing mutex ensureInterhostRoutes
2016/03/06 21:53:26 Agent: Unspecified error (Agent: Can't create IP route (target 10.1.0.1/16 -> 192.168.99.11: cause External command unsuccessful (/sbin/ip [ro add 10.1.0.1/16 via 192.168.99.11]: exit status 2)))
```
Bit odd, since this was fixed and merged from https://github.com/romana/core/pull/42