### PR TITLE
Correct type for request_token. Capture result of tx.Create

### DIFF
--- a/ipam/store.go
+++ b/ipam/store.go
@@ -16,7 +16,7 @@
 package ipam
 
 import (
-	//	"database/sql"
+	"database/sql"
 	"github.com/romana/core/common"
 	"log"
 )
@@ -28,7 +28,7 @@ type Vm struct {
 	SegmentId    string `json:"segment_id"`
 	HostId       string `json:"host_id"`
 	Name         string `json:"instance"`
-	RequestToken string `json:"request_token" sql:"unique"`
+	RequestToken sql.NullString `json:"request_token" sql:"unique"`
 	// Ordinal number of this VM in the host/tenant combination
 	Seq uint64 `json:"sequence"`
 	// Calculated effective sequence number of this VM --
@@ -72,8 +72,8 @@ func (ipamStore *ipamStore) addVm(stride uint, vm *Vm) error {
 	vm.EffectiveSeq = effectiveVmSeq
 	ipamVm := IpamVm{Vm: *vm}
 	tx.NewRecord(ipamVm)
-	tx.Create(&ipamVm)
-	err := common.MakeMultiError(ipamStore.DbStore.Db.GetErrors())
+	tx = tx.Create(&ipamVm)
+	err := common.MakeMultiError(tx.GetErrors())
 	if err != nil {
 		tx.Rollback()
 		return err

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/romana/core/root"
 	"github.com/romana/core/tenant"
 	"github.com/romana/core/topology"
+	"database/sql"
 	"os"
 	"time"
 	//	"reflect"
@@ -264,7 +265,7 @@ func (s *MySuite) TestIntegration(c *check.C) {
 	// Get first IP
 	myLog(c, "Get first IP")
 
-	vmIn := ipam.Vm{Name: "vm1", TenantId: fmt.Sprintf("%d", tOut.Id), SegmentId: fmt.Sprintf("%d", sOut.Id), HostId: host2.Id, RequestToken: "ttt"}
+	vmIn := ipam.Vm{Name: "vm1", TenantId: fmt.Sprintf("%d", tOut.Id), SegmentId: fmt.Sprintf("%d", sOut.Id), HostId: host2.Id, RequestToken: sql.NullString{String:"ttt", Valid: true}}
 	vmOut := ipam.Vm{}
 	err = client.Post("/vms", vmIn, &vmOut)
 	if err != nil {


### PR DESCRIPTION
Experiencing error when trying to get addresses from IPAM.
First one would succeed, and entry created in ipam_vms table.
After that, all fails, but doesn't accurately react to the error.

Error is: `2016/03/07 02:57:23 [Error 1062: Duplicate entry '' for key 'request_token']`
Instead of stopping, it'd proceed to allocate the same IP address for the host on multiple calls (so different pods/instances get the same address.
```
$ grep Constructing /var/log/upstart/romana-ipam.log 
2016/03/06 21:53:03 Constructing IP from Host IP 10.0.0.1/16, Tenant 2, Segment 1
2016/03/06 21:53:03 Constructing (167772160 << 24) | 167772160 | (2 << 12) | ( 1 << 8 ) | 3=10.0.33.3
2016/03/06 21:53:04 Constructing IP from Host IP 10.1.0.1/16, Tenant 2, Segment 1
2016/03/06 21:53:04 Constructing (167772160 << 24) | 167837696 | (2 << 12) | ( 1 << 8 ) | 3=10.1.33.3
2016/03/06 21:53:05 Constructing IP from Host IP 10.1.0.1/16, Tenant 2, Segment 1
2016/03/06 21:53:05 Constructing (167772160 << 24) | 167837696 | (2 << 12) | ( 1 << 8 ) | 3=10.1.33.3
```

This patch fixes both issues.
1) Replace request_token's type with NullString. It is tagged unique, but will default to an empty string (a non-NULL value from the DB's perspective).
2) When tx.Create() is called, it returns a *DB  object that contains the error. We need to keep this to check if an error occured.
