### PR TITLE
Detected by vet, this error message used the incorrect variable

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -166,7 +166,7 @@ func (a *Agent) k8sPodUpHandle(netReq NetworkRequest) error {
 	log.Println("Agent: Entering k8sPodUpHandle()")
 	namespaceIsolation, err := common.ToBool(netReq.Options[namespaceIsolationOption])
 	if err != nil {
-		msg := fmt.Sprintf("Invalid value in %s: %s", namespaceIsolation, err.Error())
+		msg := fmt.Sprintf("Invalid value in %s: %s", namespaceIsolationOption, err.Error())
 		log.Println(msg)
 		return agentErrorString(msg)
 	}


### PR DESCRIPTION
$WORKSPACE/src/github.com/romana/core/agent/agent.go:169: arg namespaceIsolation for printf verb %s of wrong type: bool

It meant to use the namespaceIsolationOption constant.