### PR TITLE
The 'form' part can't actually handle options like omitempty

### DIFF
--- a/agent/netconfig.go
+++ b/agent/netconfig.go
@@ -41,8 +41,8 @@ type NetworkRequest struct {
 // together with basic methods operating on this structure.
 type NetIf struct {
 	Name string `form:"interface_name" json:"interface_name"`
-	Mac  string `form:"mac_address,omitempty" json:"interface_name,omitempty"`
-	IP   net.IP `form:"ip_address,omitempty" json:"ip_address,omitempty"`
+	Mac  string `form:"mac_address" json:"interface_name,omitempty"`
+	IP   net.IP `form:"ip_address" json:"ip_address,omitempty"`
 }
 
 // SetIP parses and sets the IP address of the interface.


### PR DESCRIPTION
Fixes this crash on openstack. Kubernetes wasn't affected because it uses a different handler in agent.

The impact of the change is actually here:
https://github.com/romana/core/blob/master/common/middleware.go#L425
It uses those struct tags to look up a map value, and was looking up `mac_address,omitempty` instead of `mac_address`

```
[negroni] listening on [::]:9604 (asked for 0.0.0.0:9604) with configuration &{0.0.0.0:9604 0xc82017cf60 510ms 510ms 0 <nil> map[] <nil> 0xc820186410 0}
2016/03/10 03:40:15 Marshaler {} for application/x-www-form-urlencoded
2016/03/10 03:40:15 Entering formMarshaller.Unmarshal()
2016/03/10 03:40:15 Unmarshaled form interface_name=tap56180c7a-b7&ip_address=10.0.17.6&mac_address=fa%3A16%3A3e%3A1f%3A83%3Af9 to map map[interface_name:tap56180c7a-b7 i
p_address:10.0.17.6 mac_address:fa:16:3e:1f:83:f9]2016/03/10 03:40:15 httpHandler: inData addr: 859531815296
2016/03/10 03:40:15 Read interface_name=tap56180c7a-b7&ip_address=10.0.17.6&mac_address=fa%3A16%3A3e%3A1f%3A83%3Af9
2016/03/10 03:40:15 Entering formMarshaller.Unmarshal()
2016/03/10 03:40:15 Unmarshaled form interface_name=tap56180c7a-b7&ip_address=10.0.17.6&mac_address=fa%3A16%3A3e%3A1f%3A83%3Af9 to map map[interface_name:tap56180c7a-b7 i
p_address:10.0.17.6 mac_address:fa:16:3e:1f:83:f9]
2016/03/10 03:40:15 Value of Name is tap56180c7a-b7
2016/03/10 03:40:15 Value of Mac is %!s(<nil>)
panic: interface conversion: interface is nil, not string

goroutine 10 [running]:
github.com/romana/core/common.formMarshaller.Unmarshal(0xc8200d3800, 0x5a, 0x600, 0x8b3240, 0xc8201ce380, 0x0, 0x0)
        /var/lib/jenkins/jobs/core-upload/workspace/src/github.com/romana/core/common/middleware.go:429 +0xa1e
github.com/romana/core/common.(*formMarshaller).Unmarshal(0xd88630, 0xc8200d3800, 0x5a, 0x600, 0x8b3240, 0xc8201ce380, 0x0, 0x0)
        <autogenerated>:14 +0xcb
github.com/romana/core/common.wrapHandler.func2(0x7fd031f5c3a8, 0xc82019e6a0, 0xc82009a7e0)
        /var/lib/jenkins/jobs/core-upload/workspace/src/github.com/romana/core/common/middleware.go:197 +0x91a
github.com/romana/core/common.RomanaHandler.ServeHTTP(0xc820186320, 0x7fd031f5c3a8, 0xc82019e6a0, 0xc82009a7e0)
        /var/lib/jenkins/jobs/core-upload/workspace/src/github.com/romana/core/common/middleware.go:109 +0x3a
github.com/romana/core/vendor/github.com/gorilla/mux.(*Router).ServeHTTP(0xc820186280, 0x7fd031f5c3a8, 0xc82019e6a0, 0xc82009a7e0)
        /var/lib/jenkins/jobs/core-upload/workspace/src/github.com/romana/core/vendor/github.com/gorilla/mux/mux.go:100 +0x29e
net/http.(*timeoutHandler).ServeHTTP.func1(0xc82017d2c0, 0xc82019e6a0, 0xc82009a7e0, 0xc8201763f0)
        /usr/local/go/src/net/http/server.go:2077 +0x78
```