### PR TITLE
go-gettable core

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,52 +1,49 @@
-[submodule "src/github.com/romana/core/vendor/github.com/go-sql-driver/mysql"]
-	path = src/github.com/romana/core/vendor/github.com/go-sql-driver/mysql
-	url = git@github.com:go-sql-driver/mysql.git
 [submodule "vendor/github.com/go-sql-driver/mysql"]
 	path = vendor/github.com/go-sql-driver/mysql
-	url = git@github.com:go-sql-driver/mysql.git
+	url = https://github.com/go-sql-driver/mysql.git
 [submodule "vendor/github.com/gorilla/mux"]
 	path = vendor/github.com/gorilla/mux
-	url = git@github.com:gorilla/mux.git
+	url = https://github.com/gorilla/mux.git
 [submodule "vendor/github.com/gorilla/context"]
 	path = vendor/github.com/gorilla/context
-	url = git@github.com:gorilla/context.git
+	url = https://github.com/gorilla/context.git
 [submodule "vendor/github.com/codegangsta/negroni"]
 	path = vendor/github.com/codegangsta/negroni
-	url = git@github.com:codegangsta/negroni.git
+	url = https://github.com/codegangsta/negroni.git
 [submodule "vendor/github.com/unrolled/render"]
 	path = vendor/github.com/unrolled/render
-	url = git@github.com:unrolled/render.git
+	url = https://github.com/unrolled/render.git
 [submodule "vendor/github.com/K-Phoen/http-negotiate"]
 	path = vendor/github.com/K-Phoen/http-negotiate
-	url = git@github.com:K-Phoen/http-negotiate.git
+	url = https://github.com/K-Phoen/http-negotiate.git
 [submodule "vendor/github.com/K-Phoen/negotiation"]
 	path = vendor/github.com/K-Phoen/negotiation
-	url = git@github.com:K-Phoen/negotiation.git
+	url = https://github.com/K-Phoen/negotiation.git
 [submodule "vendor/github.com/go-yaml/yaml"]
 	path = vendor/github.com/go-yaml/yaml
-	url = git@github.com:go-yaml/yaml.git
+	url = https://github.com/go-yaml/yaml.git
 [submodule "vendor/github.com/mitchellh/mapstructure"]
 	path = vendor/github.com/mitchellh/mapstructure
-	url = git@github.com:mitchellh/mapstructure.git
+	url = https://github.com/mitchellh/mapstructure.git
 [submodule "vendor/github.com/qor/inflection"]
 	path = vendor/github.com/qor/inflection
-	url = git@github.com:qor/inflection.git
+	url = https://github.com/qor/inflection.git
 [submodule "vendor/github.com/lib/pq"]
 	path = vendor/github.com/lib/pq
-	url = git@github.com:lib/pq.git
+	url = https://github.com/lib/pq.git
 [submodule "vendor/github.com/go-check/check"]
 	path = vendor/github.com/go-check/check
-	url = git@github.com:go-check/check.git
+	url = https://github.com/go-check/check.git
 [submodule "vendor/github.com/jinzhu/gorm"]
 	path = vendor/github.com/jinzhu/gorm
-	url = git@github.com:jinzhu/gorm
+	url = https://github.com/jinzhu/gorm
 [submodule "vendor/github.com/dgrijalva/jwt-go"]
 	path = vendor/github.com/dgrijalva/jwt-go
-	url = git@github.com:dgrijalva/jwt-go.git
+	url = https://github.com/dgrijalva/jwt-go.git
 [submodule "vendor/github.com/mattn/go-sqlite3"]
 	path = vendor/github.com/mattn/go-sqlite3
-	url = git@github.com:mattn/go-sqlite3.git
+	url = https://github.com/mattn/go-sqlite3.git
 [submodule "vendor/github.com/pborman/uuid"]
 	path = vendor/github.com/pborman/uuid
-	url = git@github.com:pborman/uuid.git
+	url = https://github.com/pborman/uuid.git
 


### PR DESCRIPTION
Changes submodules to https instead of git@ addresses, so that a github account isn't required when doing a 'get'.

However, an error still occurs with go v1.5.x because of golang/go/issues/12612, but is fixed in 1.6.
The workaround for the error is already documented in the README.