### PR TITLE
Implement #300, #301 and #303 in agent

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -165,14 +165,7 @@ func (a *Agent) index(input interface{}, ctx common.RestContext) (interface{}, e
 // 4. Provisions firewall rules
 func (a *Agent) k8sPodUpHandle(netReq NetworkRequest) error {
 	log.Println("Agent: Entering k8sPodUpHandle()")
-	namespaceIsolation, err := common.ToBool(netReq.Options[namespaceIsolationOption])
-	if err != nil {
-		msg := fmt.Sprintf("Invalid value in %s: %s", namespaceIsolationOption, err.Error())
-		log.Println(msg)
-		return agentErrorString(msg)
-	}
 
-	log.Printf("Isolation is %t", namespaceIsolation)
 	netif := netReq.NetIf
 	if netif.Name == "" {
 		return agentErrorString("Agent: Interface name required")
@@ -199,7 +192,7 @@ func (a *Agent) k8sPodUpHandle(netReq NetworkRequest) error {
 	}
 	log.Print("Agent: provisioning firewall")
 
-	if err := provisionK8SFirewallRules(netReq, a, namespaceIsolation); err != nil {
+	if err := provisionK8SFirewallRules(netReq, a); err != nil {
 		log.Print(agentError(err))
 		return agentError(err)
 	}
@@ -265,23 +258,3 @@ func (a *Agent) Initialize() error {
 	log.Printf("Entering Agent.Initialize()")
 	return a.identifyCurrentHost()
 }
-
-/* development code
-func DryRun() {
-	tif := NetIf{"eth0", "B", "10.0.0.1"}
-	firewall, _ := NewFirewall(tif)
-	err := firewall.ParseNetIf(tif)
-	if err != nil {
-		fmt.Println(err)
-	}
-	fmt.Println(firewall.u32Filter)
-	// for chain := range firewall.chains {
-	// 	fmt.Println(firewall.chains[chain])
-	// }
-	firewall.CreateChains([]int{1, 2, 3})
-	a.Helper.ensureInterHostRoutes()
-	if _, err := a.Helper.DhcpPid(); err != nil {
-		fmt.Println(err)
-	}
-}
-*/

--- a/agent/firewall_test.go
+++ b/agent/firewall_test.go
@@ -42,7 +42,7 @@ func TestNewChains(t *testing.T) {
 
 	newChains := fw.detectMissingChains()
 
-	if len(newChains) != 3 {
+	if len(newChains) != 4 {
 		t.Error("TestNewChains failed")
 	}
 
@@ -152,8 +152,6 @@ func TestCreateRules(t *testing.T) {
 	fw.CreateRules(0)
 
 	expect := strings.Join([]string{
-		"/sbin/iptables -A ROMANA-T0S0-INPUT -d 172.17.0.1/32 -p icmp -m icmp --icmp-type 0 -m state --state RELATED,ESTABLISHED -j ACCEPT",
-		"/sbin/iptables -A ROMANA-T0S0-INPUT -d 172.17.0.1/32 -p tcp -m tcp --sport 22 -j ACCEPT",
 		"/sbin/iptables -A ROMANA-T0S0-INPUT -d 255.255.255.255/32 -p udp -m udp --sport 68 --dport 67 -j ACCEPT",
 	}, "\n")
 

--- a/agent/service_test.go
+++ b/agent/service_test.go
@@ -18,11 +18,12 @@ package agent
 
 import (
 	"fmt"
-	"github.com/romana/core/common"
-	"log"
-	"net"
 	"os"
 	"testing"
+	// Dependencies for disabled test below
+	// "github.com/romana/core/common"
+	// "log"
+	// "net"
 )
 
 func startAgent(t *testing.T) {
@@ -41,6 +42,10 @@ func startAgent(t *testing.T) {
 	fmt.Println(msg)
 }
 
+/*
+Disabled since only thing it was testing is isolation flag, which is deprecated.
+Left here as a template for future tests, maybe
+
 // TestK8SHandler will test K8S handler
 func TestK8SHandler(t *testing.T) {
 	startAgent(t)
@@ -58,3 +63,4 @@ func TestK8SHandler(t *testing.T) {
 	restClient.Post("http://localhost:8899/kubernetes-pod-up", nr, &result)
 	log.Printf("Sent to agent %v, agent returned %v", nr, result)
 }
+*/


### PR DESCRIPTION
I reused existing code iptables code even though it's overkill for the task right now, but I'm trying to keep changes manageable, preparing for policy agent implementation.

I removed default rules, so openstack now won't support ssh and icmp by default.