### PR TITLE
Ipam allocate endpoints

### DIFF
--- a/ipam/ipam.go
+++ b/ipam/ipam.go
@@ -54,8 +54,8 @@ func (ipam *IPAM) Routes() common.Routes {
 		},
 		common.Route{
 			Method:          "GET",
-			Pattern:         "/allocateIpByName",
-			Handler:         ipam.legacyAllocateIpByName,
+			Pattern:         "/allocateIP",
+			Handler:         ipam.allocateIP,
 			MakeMessage:     nil,
 			UseRequestToken: false,
 		},
@@ -63,18 +63,41 @@ func (ipam *IPAM) Routes() common.Routes {
 	return routes
 }
 
-// handleHost handles request for a specific host's info
-func (ipam *IPAM) legacyAllocateIpByName(input interface{}, ctx common.RestContext) (interface{}, error) {
-	tenantName := ctx.QueryVariables["tenantName"][0]
-	segmentName := ctx.QueryVariables["segmentName"][0]
-	hostName := ctx.QueryVariables["hostName"][0]
-	names := ctx.QueryVariables["instanceName"]
-	name := "Endpoint"
-	if len(names) > 0 {
-		name = names[0]
+// allocateIP finds internal Romana information based on clusterType and provided parameters, then adds
+// that endpoint to IPAM, and passes through the allocated IP
+func (ipam *IPAM) allocateIP(input interface{}, ctx common.RestContext) (interface{}, error) {
+	clusterType := ctx.QueryVariables.Get("clusterType")
+	var tenantParam, segmentName, hostName, instanceName string
+	switch clusterType {
+	case "kubernetes":
+		tenantParam = ctx.QueryVariables.Get("tenantName")
+		segmentName = ctx.QueryVariables.Get("segmentName")
+		hostName = ctx.QueryVariables.Get("hostName")
+		instanceName = ctx.QueryVariables.Get("instanceName")
+	case "openstack":
+		tenantParam = ctx.QueryVariables.Get("tenantID")
+		segmentName = ctx.QueryVariables.Get("segmentName")
+		hostName = ctx.QueryVariables.Get("hostName")
+		instanceName = ctx.QueryVariables.Get("instanceName")
+	case "": // Missing or empty
+		return nil, errors.New("Missing or empty clusterType parameter")
+	default:  // Invalid
+		return nil, fmt.Errorf("Invalid clusterType '%s'", clusterType)
 	}
-	Endpoint := Endpoint{}
-	Endpoint.Name = name
+
+	// check for missing/empty required parameters
+	if tenantParam == "" {
+		return nil, errors.New("Missing or empty tenantName/tenantID parameter")
+	}
+	if segmentName == "" {
+		return nil, errors.New("Missing or empty segmentName parameter")
+	}
+	if hostName == "" {
+		return nil, errors.New("Missing or empty hostName parameter")
+	}
+
+	endpoint := Endpoint{}
+	endpoint.Name = instanceName // not required, may be empty
 
 	client, err := common.NewRestClient("", common.GetRestClientConfig(ipam.config))
 	if err != nil {
@@ -101,10 +124,10 @@ func (ipam *IPAM) legacyAllocateIpByName(input interface{}, ctx common.RestConte
 	}
 
 	found := false
-	for i := range hosts {
-		if hosts[i].Name == hostName {
+	for _, h := range hosts {
+		if h.Name == hostName {
 			found = true
-			Endpoint.HostId = hosts[i].Id
+			endpoint.HostId = h.Id
 			break
 		}
 	}
@@ -113,7 +136,7 @@ func (ipam *IPAM) legacyAllocateIpByName(input interface{}, ctx common.RestConte
 		log.Printf(msg)
 		return nil, errors.New(msg)
 	}
-	log.Printf("Host name %s has ID %s", hostName, Endpoint.HostId)
+	log.Printf("Host name %s has ID %s", hostName, endpoint.HostId)
 
 	tenantSvcUrl, err := client.GetServiceUrl(ipam.config.Common.Api.RootServiceUrl, "tenant")
 	if err != nil {
@@ -129,21 +152,30 @@ func (ipam *IPAM) legacyAllocateIpByName(input interface{}, ctx common.RestConte
 		return nil, err
 	}
 	found = false
-	var i int
-	for i = range tenants {
-		if tenants[i].Name == tenantName {
-			found = true
-			Endpoint.TenantId = fmt.Sprintf("%d", tenants[i].ID)
-			log.Printf("IPAM: Tenant name %s has ID %s, original %d\n", tenantName, Endpoint.TenantId, tenants[i].ID)
+	for _, t := range tenants {
+		switch clusterType {
+		case "kubernetes":
+			if t.Name == tenantParam {
+				found = true
+			}
+		case "openstack":
+			if t.ExternalID == tenantParam {
+				found = true
+			}
+		}
+
+		if found {
+			endpoint.TenantId = fmt.Sprintf("%d", t.ID)
+			log.Printf("IPAM: Tenant '%s' has ID %s, original %d", tenantParam, endpoint.TenantId, t.ID)
 			break
 		}
 	}
 	if !found {
-		return nil, errors.New("Tenant with name " + tenantName + " not found")
+		return nil, fmt.Errorf("Tenant with name '%s' not found", tenantParam)
 	}
-	log.Printf("IPAM: Tenant name %s has ID %s, original %d\n", tenantName, Endpoint.TenantId, tenants[i].ID)
+	log.Printf("IPAM: Tenant name %s has ID %s", tenantParam, endpoint.TenantId)
 
-	segmentsUrl := fmt.Sprintf("/tenants/%s/segments", Endpoint.TenantId)
+	segmentsUrl := fmt.Sprintf("/tenants/%s/segments", endpoint.TenantId)
 	var segments []tenant.Segment
 	err = client.Get(segmentsUrl, &segments)
 	if err != nil {
@@ -153,15 +185,15 @@ func (ipam *IPAM) legacyAllocateIpByName(input interface{}, ctx common.RestConte
 	for _, s := range segments {
 		if s.Name == segmentName {
 			found = true
-			Endpoint.SegmentId = fmt.Sprintf("%d", s.Id)
+			endpoint.SegmentId = fmt.Sprintf("%d", s.Id)
 			break
 		}
 	}
 	if !found {
-		return nil, errors.New("Segment with name " + hostName + " not found")
+		return nil, fmt.Errorf("Segment with name '%s' not found", segmentName)
 	}
-	log.Printf("Segment name %s has ID %s", segmentName, Endpoint.SegmentId)
-	return ipam.addEndpoint(&Endpoint, ctx)
+	log.Printf("Segment name %s has ID %s", segmentName, endpoint.SegmentId)
+	return ipam.addEndpoint(&endpoint, ctx)
 }
 
 // addEndpoint handles request to add an endpoint and

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -416,7 +416,7 @@ func (s *MySuite) TestRootTopoTenantIpamInteraction(c *check.C) {
 
 	// Try legacy request using tenantName
 	endpointOut := ipam.Endpoint{}
-	legacyURL := "/allocateIP?clusterType=kubernetes&tenantName=t1&segmentName=s1&hostName=HOST2000&instanceName=bla"
+	legacyURL := "/allocateIP?tenantName=t1&segmentName=s1&hostName=HOST2000&instanceName=bla"
 	myLog(c, "Calling legacy URL", legacyURL)
 
 	err = client.Get(legacyURL, &endpointOut)
@@ -429,7 +429,7 @@ func (s *MySuite) TestRootTopoTenantIpamInteraction(c *check.C) {
 	myLog(c, "Legacy IP:", endpointOut.Ip)
 
 	// Try legacy request using tenantID
-	legacyURL = "/allocateIP?clusterType=openstack&tenantID=t1&segmentName=s1&hostName=HOST2000&instanceName=bla"
+	legacyURL = "/allocateIP?tenantID=t1&segmentName=s1&hostName=HOST2000&instanceName=bla"
 	myLog(c, "Calling legacy URL", legacyURL)
 
 	err = client.Get(legacyURL, &endpointOut)

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -414,9 +414,22 @@ func (s *MySuite) TestRootTopoTenantIpamInteraction(c *check.C) {
 	// Expecting 17 because tenant 2 and segment 2: 1 << 12 | 1 << 4
 	c.Assert(t2s2h2EpOut.Ip, check.Equals, "10.1.17.3")
 
-	// Try legacy request
+	// Try legacy request using tenantName
 	endpointOut := ipam.Endpoint{}
-	legacyURL := "/allocateIpByName?tenantName=t1&segmentName=s1&hostName=HOST2000&instanceName=bla"
+	legacyURL := "/allocateIP?tenantName=t1&segmentName=s1&hostName=HOST2000&instanceName=bla"
+	myLog(c, "Calling legacy URL", legacyURL)
+
+	err = client.Get(legacyURL, &endpointOut)
+
+	if err != nil {
+		myLog(c, "Error %s\n", err)
+		c.Error(err)
+	}
+	myLog(c, "Legacy received:", endpointOut)
+	myLog(c, "Legacy IP:", endpointOut.Ip)
+
+	// Try legacy request using tenantID
+	legacyURL = "/allocateIP?tenantID=t1&segmentName=s1&hostName=HOST2000&instanceName=bla"
 	myLog(c, "Calling legacy URL", legacyURL)
 
 	err = client.Get(legacyURL, &endpointOut)

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -416,7 +416,7 @@ func (s *MySuite) TestRootTopoTenantIpamInteraction(c *check.C) {
 
 	// Try legacy request using tenantName
 	endpointOut := ipam.Endpoint{}
-	legacyURL := "/allocateIP?tenantName=t1&segmentName=s1&hostName=HOST2000&instanceName=bla"
+	legacyURL := "/allocateIP?clusterType=kubernetes&tenantName=t1&segmentName=s1&hostName=HOST2000&instanceName=bla"
 	myLog(c, "Calling legacy URL", legacyURL)
 
 	err = client.Get(legacyURL, &endpointOut)
@@ -429,7 +429,7 @@ func (s *MySuite) TestRootTopoTenantIpamInteraction(c *check.C) {
 	myLog(c, "Legacy IP:", endpointOut.Ip)
 
 	// Try legacy request using tenantID
-	legacyURL = "/allocateIP?tenantID=t1&segmentName=s1&hostName=HOST2000&instanceName=bla"
+	legacyURL = "/allocateIP?clusterType=openstack&tenantID=t1&segmentName=s1&hostName=HOST2000&instanceName=bla"
 	myLog(c, "Calling legacy URL", legacyURL)
 
 	err = client.Get(legacyURL, &endpointOut)


### PR DESCRIPTION
This PR changes the behaviour of the "legacy allocate IP" path in the IPAM service.
Now, it takes a "clusterType" parameter with values either 'kubernetes' or 'openstack'.

For kubernetes, it will expect a tenantName parameter, and compare it to the Name field in the tenant data.
For openstack/devstack, it will expect a tenantID parameter, and compare it to the ExternalID field in the tenant data.