### PR TITLE
Fix/k8s listener

### DIFF
--- a/common/helpers.go
+++ b/common/helpers.go
@@ -46,6 +46,26 @@ func initEnviron() {
 	}
 }
 
+// CleanURL is similar to path.Clean() but to work on URLs
+func CleanURL(url string) (string, error) {
+	elements := strings.Split(url, "/")
+	retval := ""
+	if len(elements) < 3 {
+		return "", errors.New("Invalid URL")
+	}
+	retval = elements[0] + "//" + elements[2] 
+	if len(elements) == 3 {
+		return retval, nil
+	}
+	for i := 3; i< len(elements);i++  {
+		if elements[i] == "" {
+			continue
+		}
+		retval += "/" + elements[i]
+	}
+	return retval, nil
+}
+
 func PressEnterToContinue() {
 	fmt.Println("Press ENTER to continue")
 	scanner := bufio.NewScanner(os.Stdin)

--- a/common/testdata/romana.sample.yaml
+++ b/common/testdata/romana.sample.yaml
@@ -60,5 +60,8 @@ services:
       port: 9606
     config:
       kubernetes_url : "http://localhost"
-      url_prefix: "apis/romana.io/demo/v1/namespaces"
+      namespace_notification_path: "/api/v1/namespaces/?watch=true"
+      policy_notification_path_prefix : "/apis/romana.io/demo/v1/namespaces/"
+      policy_notification_path_postfix : "/networkpolicys/?wath=true"
       segment_label_name: "tier"
+     

--- a/romana/kubernetes/listener.go
+++ b/romana/kubernetes/listener.go
@@ -159,6 +159,13 @@ const (
 	networkPolicyActionModify
 )
 
+// kubeListener is a Service that listens to updates
+// from Kubernetes by connecting to the endpoints specified 
+// and consuming chunked JSON documents. The endpoints are
+// constructed from kubeUrl and the following paths:
+// 1. namespaceNotificationPath for namespace additions/deletions
+// 2. policyNotificationPathPrefix + <namespace name> + policyNotificationPathPostfix
+//    for policy additions/deletions.
 type kubeListener struct {
 	config                    common.ServiceConfig
 	restClient                *common.RestClient

--- a/romana/kubernetes/listener.go
+++ b/romana/kubernetes/listener.go
@@ -163,6 +163,7 @@ type kubeListener struct {
 	config           common.ServiceConfig
 	restClient       *common.RestClient
 	kubeUrl          string
+	nsUrl            string
 	urlPrefix        string
 	segmentLabelName string
 }
@@ -192,6 +193,10 @@ func (l *kubeListener) SetConfig(config common.ServiceConfig) error {
 	l.segmentLabelName = m["segment_label_name"].(string)
 	if l.segmentLabelName == "" {
 		return errors.New("segment_label_name required.")
+	}
+	l.nsUrl = m["namespaces_url"].(string)
+	if l.nsUrl == "" {
+		return errors.New("namespaces_url required.")
 	}
 
 	return nil
@@ -360,7 +365,7 @@ func (l *kubeListener) applyNetworkPolicy(action networkPolicyAction, romanaNetw
 
 func (l *kubeListener) Initialize() error {
 	log.Printf("%s: Starting server", l.Name())
-	nsUrl := fmt.Sprintf("%s/%s", l.kubeUrl, l.urlPrefix)
+	nsUrl := fmt.Sprintf("%s/%s", l.kubeUrl, l.nsUrl)
 	done := make(chan Done)
 	nsEvents, err := l.nsWatch(done, nsUrl)
 	if err != nil {

--- a/romana/kubernetes/listener.go
+++ b/romana/kubernetes/listener.go
@@ -160,12 +160,13 @@ const (
 )
 
 type kubeListener struct {
-	config           common.ServiceConfig
-	restClient       *common.RestClient
-	kubeUrl          string
-	nsUrl            string
-	urlPrefix        string
-	segmentLabelName string
+	config                    common.ServiceConfig
+	restClient                *common.RestClient
+	kubeUrl                   string
+	namespaceNotificationPath string
+	policyNotificationPathPrefix string
+	policyNotificationPathPostfix string
+	segmentLabelName          string
 }
 
 // Routes returns various routes used in the service.
@@ -182,25 +183,33 @@ func (l *kubeListener) Name() string {
 // SetConfig implements SetConfig function of the Service interface.
 func (l *kubeListener) SetConfig(config common.ServiceConfig) error {
 	m := config.ServiceSpecific
-	l.kubeUrl = m["kubernetes_url"].(string)
-	if l.kubeUrl == "" {
+	if m["kubernetes_url"] == "" {
 		return errors.New("kubernetes_url required.")
 	}
-	l.urlPrefix = m["url_prefix"].(string)
-	if l.urlPrefix == "" {
-		return errors.New("url_prefix required.")
+	l.kubeUrl = m["kubernetes_url"].(string)
+	
+	if m["namespace_notification_path"] == "" {
+		return errors.New("namespace_notification_path required.")
 	}
-	l.segmentLabelName = m["segment_label_name"].(string)
-	if l.segmentLabelName == "" {
+	l.namespaceNotificationPath = m["namespace_notification_path"].(string)
+	
+	if m["policy_notification_path_prefix"] == "" {
+		return errors.New("policy_notification_path_prefix required.")
+	}
+	l.policyNotificationPathPrefix = m["policy_notification_path_prefix"].(string)
+	
+	
+	if m["policy_notification_path_postfix"] == "" {
+		return errors.New("policy_notification_path_postfix required.")
+	}
+	l.policyNotificationPathPostfix = m["policy_notification_path_postfix"].(string)
+	
+	if m["segment_label_name"] == "" {
 		return errors.New("segment_label_name required.")
 	}
-	l.nsUrl = m["namespaces_url"].(string)
-	if l.nsUrl == "" {
-		return errors.New("namespaces_url required.")
-	}
-
+	l.segmentLabelName = m["segment_label_name"].(string)
+	
 	return nil
-
 }
 
 // Run configures and runs listener service.
@@ -365,7 +374,11 @@ func (l *kubeListener) applyNetworkPolicy(action networkPolicyAction, romanaNetw
 
 func (l *kubeListener) Initialize() error {
 	log.Printf("%s: Starting server", l.Name())
-	nsUrl := fmt.Sprintf("%s/%s", l.kubeUrl, l.nsUrl)
+	nsUrl, err := common.CleanURL(fmt.Sprintf("%s%s", l.kubeUrl, l.namespaceNotificationPath))
+	if err != nil {
+		return err
+	}
+	log.Printf("Starting to listen on %s", nsUrl)
 	done := make(chan Done)
 	nsEvents, err := l.nsWatch(done, nsUrl)
 	if err != nil {

--- a/romana/kubernetes/listener/main.go
+++ b/romana/kubernetes/listener/main.go
@@ -36,5 +36,12 @@ func main() {
 		return
 	}
 	cred := common.MakeCredentialFromCliArgs(*username, *password)
-	kubernetes.Run(*rootURL, cred)
+	svcInfo, err := kubernetes.Run(*rootURL, cred)
+	if err != nil {
+		panic(err)
+	}
+	for {
+		msg := <-svcInfo.Channel
+		fmt.Println(msg)
+	}
 }

--- a/romana/kubernetes/processor_test.go
+++ b/romana/kubernetes/processor_test.go
@@ -32,9 +32,12 @@ func TestResourceProcessor(t *testing.T) {
 	l := kubeListener{}
 	cfg := common.ServiceConfig{}
 	cfg.ServiceSpecific = make(map[string]interface{})
-	cfg.ServiceSpecific["url_prefix"] = "apis/romana.io/demo/v1/namespaces"
-	cfg.ServiceSpecific["segment_label_name"] = "tier"
 	cfg.ServiceSpecific["kubernetes_url"] = "http://192.168.0.10:8080"
+	cfg.ServiceSpecific["namespace_notification_path"] = "/api/v1/namespaces/?watch=true"
+	cfg.ServiceSpecific["policy_notification_path_prefix"] = "/apis/romana.io/demo/v1/namespaces/"
+	cfg.ServiceSpecific["policy_notification_path_postfix"] = "/networkpolicys/?wath=true"
+	cfg.ServiceSpecific["segment_label_name"] = "tier"
+
 	err := l.SetConfig(cfg)
 	if err != nil {
 		t.Error(err.Error())

--- a/romana/kubernetes/resources.go
+++ b/romana/kubernetes/resources.go
@@ -23,7 +23,7 @@ import (
 )
 
 const (
-	urlPostfix = "api/v1/namespaces/?watch=true"
+	urlPostfix = "networkpolicys/?watch=true"
 	selector   = "podSelector"
 )
 

--- a/romana/kubernetes/resources.go
+++ b/romana/kubernetes/resources.go
@@ -18,13 +18,13 @@ package kubernetes
 import (
 	"encoding/json"
 	"fmt"
+	"github.com/romana/core/common"
 	"log"
 	"net/http"
 )
 
 const (
-	urlPostfix = "networkpolicys/?watch=true"
-	selector   = "podSelector"
+	selector = "podSelector"
 )
 
 // Done is an alias for empty struct, used to make broadcast channels
@@ -146,12 +146,14 @@ func (l *kubeListener) nsWatch(done <-chan Done, url string) (<-chan Event, erro
 	return out, nil
 }
 
-// Produce method listens for resource updates happening within givcen namespace
-// and publishes this updates in a channel
+// Produce method listens for resource updates happening within given namespace
+// and publishes these updates in a channel.
 func (ns KubeObject) produce(out chan Event, done <-chan Done, kubeListener *kubeListener) error {
-	url := fmt.Sprintf("%s/%s/%s/%s", kubeListener.kubeUrl, kubeListener.urlPrefix, ns.Metadata.Name, urlPostfix)
-	log.Println("Launching producer to listen on ", url)
-
+	url, err := common.CleanURL(fmt.Sprintf("%s/%s/%s%s", kubeListener.kubeUrl, kubeListener.policyNotificationPathPrefix, ns.Metadata.Name, kubeListener.policyNotificationPathPostfix))
+	if err != nil {
+		return err
+	}
+	log.Printf("Launching producer to listen for policy notifications on namespace %s at URL %s ", ns.Metadata.Name, url)
 	resp, err := http.Get(url)
 	if err != nil {
 		return err


### PR DESCRIPTION
So, @debedb. I've figured out why kubernetes listener service wasn't working. There were 2 reasons really:

* you missed nsUrl from original code and tried to use urlPrefix instead - I've fixed that
* you missed for {} loop in main.go - that's why service used to exit after the first run
What need to happen now:

* could you please fix tests for kubernetes_listener so they would take in account nsUrl.