### PR TITLE
Feature/stas kube listener for 1.3

### DIFF
--- a/agent/helpers.go
+++ b/agent/helpers.go
@@ -116,7 +116,7 @@ func (h Helper) createRoute(ip net.IP, netmask string, via string, dest string, 
 // Error if failed, nil if success.
 func (h Helper) ensureRouteToEndpoint(netif *NetIf) error {
 	mask := fmt.Sprintf("%d", h.Agent.networkConfig.EndpointNetmaskSize())
-	glog.V(1).Info("Ensuring routes for ", netif.IP, " ", netif.Name)
+	glog.V(1).Infoln("Ensuring routes for ", netif.IP, " ", netif.Name)
 	glog.V(1).Info("Acquiring mutex ensureRouteToEndpoint")
 	h.ensureRouteToEndpointMutex.Lock()
 	defer func() {

--- a/pkg/util/firewall/iptables.go
+++ b/pkg/util/firewall/iptables.go
@@ -618,7 +618,7 @@ func (fw IPtables) EnsureRule(rule *IPtablesRule, opType RuleState) error {
 			args = append(args, []string{"-I"}...)
 		}
 	} else {
-		glog.Infof("In EnsureRule - nothing to do ", rule.Body)
+		glog.Infoln("In EnsureRule - nothing to do ", rule.Body)
 		return nil
 	}
 

--- a/romana/kubernetes/listener.go
+++ b/romana/kubernetes/listener.go
@@ -239,10 +239,10 @@ func (l *kubeListener) translateNetworkPolicy(kubePolicy *KubeObject) (common.Po
 	romanaPolicy.Peers = []common.Endpoint{}
 	romanaPolicy.Rules = common.Rules{}
 	// TODO range
-	// from := kubePolicy.Spec.AllowIncoming[0].From
+	// from := kubePolicy.Spec.Ingress[0].From
 	// This is subject to change once the network specification in Kubernetes is finalized.
 	// Right now it is a work in progress.
-	for _, ingress := range kubePolicy.Spec.AllowIncoming {
+	for _, ingress := range kubePolicy.Spec.Ingress {
 		for _, entry := range ingress.From {
 			pods := entry.Pods
 			fromKubeSegmentID := pods.MatchLabels[l.segmentLabelName]
@@ -257,7 +257,7 @@ func (l *kubeListener) translateNetworkPolicy(kubePolicy *KubeObject) (common.Po
 			romanaPolicy.Peers = append(romanaPolicy.Peers, peer)
 		}
 		// TODO range
-		// toPorts := kubePolicy.Spec.AllowIncoming[0].ToPorts
+		// toPorts := kubePolicy.Spec.Ingress[0].ToPorts
 		for _, toPort := range ingress.ToPorts {
 			proto := strings.ToLower(toPort.Protocol)
 			ports := []uint{toPort.Port}

--- a/romana/kubernetes/listener.go
+++ b/romana/kubernetes/listener.go
@@ -223,7 +223,7 @@ func (l *kubeListener) translateNetworkPolicy(kubePolicy *KubeObject) (common.Po
 	tenantID := t.ID
 	tenantExternalID := t.ExternalID
 
-	kubeSegmentID := kubePolicy.Spec.PodSelector[l.segmentLabelName]
+	kubeSegmentID := kubePolicy.Spec.PodSelector.MatchLabels[l.segmentLabelName]
 	if kubeSegmentID == "" {
 		return *romanaPolicy, common.NewError("Expected segment to be specified in podSelector part as '%s'", l.segmentLabelName)
 	}
@@ -237,13 +237,15 @@ func (l *kubeListener) translateNetworkPolicy(kubePolicy *KubeObject) (common.Po
 	romanaPolicy.AppliedTo = make([]common.Endpoint, 1)
 	romanaPolicy.AppliedTo[0] = appliedTo
 	romanaPolicy.Peers = []common.Endpoint{}
-	from := kubePolicy.Spec.AllowIncoming.From
+	romanaPolicy.Rules = common.Rules{}
+	// TODO range
+	// from := kubePolicy.Spec.AllowIncoming[0].From
 	// This is subject to change once the network specification in Kubernetes is finalized.
 	// Right now it is a work in progress.
-	if from != nil {
-		for _, entry := range from {
+	for _, ingress := range kubePolicy.Spec.AllowIncoming {
+		for _, entry := range ingress.From {
 			pods := entry.Pods
-			fromKubeSegmentID := pods[l.segmentLabelName]
+			fromKubeSegmentID := pods.MatchLabels[l.segmentLabelName]
 			if fromKubeSegmentID == "" {
 				return *romanaPolicy, common.NewError("Expected segment to be specified in podSelector part as '%s'", l.segmentLabelName)
 			}
@@ -254,9 +256,9 @@ func (l *kubeListener) translateNetworkPolicy(kubePolicy *KubeObject) (common.Po
 			peer := common.Endpoint{TenantID: tenantID, TenantExternalID: tenantExternalID, SegmentID: fromSegment.ID, SegmentExternalID: fromSegment.ExternalID}
 			romanaPolicy.Peers = append(romanaPolicy.Peers, peer)
 		}
-		toPorts := kubePolicy.Spec.AllowIncoming.ToPorts
-		romanaPolicy.Rules = common.Rules{}
-		for _, toPort := range toPorts {
+		// TODO range
+		// toPorts := kubePolicy.Spec.AllowIncoming[0].ToPorts
+		for _, toPort := range ingress.ToPorts {
 			proto := strings.ToLower(toPort.Protocol)
 			ports := []uint{toPort.Port}
 			rule := common.Rule{Protocol: proto, Ports: ports}

--- a/romana/kubernetes/processor.go
+++ b/romana/kubernetes/processor.go
@@ -17,10 +17,6 @@ package kubernetes
 
 import ()
 
-/*
-{"type":"ADDED","object":{"apiVersion":"romana.io/demo/v1","kind":"NetworkPolicy","metadata":{"name":"pol1","namespace":"default","selfLink":"/apis/romana.io/demo/v1/namespaces/default/networkpolicys/pol1","uid":"d7036130-e119-11e5-aab8-0213e1312dc5","resourceVersion":"119875","creationTimestamp":"2016-03-03T08:28:00Z","labels":{"owner":"t1"}},"spec":{"allowIncoming":{"from":[{"pods":{"tier":"frontend"}}],"toPorts":[{"port":80,"protocol":"TCP"}]},"podSelector":{"tier":"backend"}}}}
-*/
-
 // Process is a goroutine that consumes resource update events and:
 // 1. On receiving an added or deleted event:
 //    a. If the Object Kind is NetworkPolicy, translates the body (Object of the event)

--- a/romana/kubernetes/processor_test.go
+++ b/romana/kubernetes/processor_test.go
@@ -19,7 +19,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"github.com/romana/core/common"
-	//	"gopkg.in/gcfg.v1"
 	"testing"
 	"time"
 )

--- a/romana/kubernetes/resources.go
+++ b/romana/kubernetes/resources.go
@@ -72,7 +72,7 @@ type FromEntry struct {
 	Pods PodSelector `json:"podSelector"`
 }
 
-type AllowIncoming struct {
+type Ingress struct {
 	From    []FromEntry `json:"from"`
 	ToPorts []ToPort    `json:"ports"`
 }
@@ -84,8 +84,8 @@ type ToPort struct {
 
 // TODO need to find a way to use different specs for different resources.
 type Spec struct {
-	AllowIncoming []AllowIncoming `json:"ingress"`
-	PodSelector   PodSelector   `json:"podSelector"`
+	Ingress     []Ingress   `json:"ingress"`
+	PodSelector PodSelector `json:"podSelector"`
 }
 
 // Metadata is a representation of metadata in kubernetes object

--- a/romana/kubernetes/resources.go
+++ b/romana/kubernetes/resources.go
@@ -64,15 +64,17 @@ func (o KubeObject) makeId() string {
 	return id
 }
 
-type PodSelector map[string]string
+type PodSelector struct {
+	MatchLabels map[string]string `json:"matchLabels"`
+}
 
 type FromEntry struct {
-	Pods PodSelector `json:"pods"`
+	Pods PodSelector `json:"podSelector"`
 }
 
 type AllowIncoming struct {
 	From    []FromEntry `json:"from"`
-	ToPorts []ToPort    `json:"toPorts"`
+	ToPorts []ToPort    `json:"ports"`
 }
 
 type ToPort struct {
@@ -82,7 +84,7 @@ type ToPort struct {
 
 // TODO need to find a way to use different specs for different resources.
 type Spec struct {
-	AllowIncoming AllowIncoming `json:"allowIncoming"`
+	AllowIncoming []AllowIncoming `json:"ingress"`
 	PodSelector   PodSelector   `json:"podSelector"`
 }
 

--- a/romana/kubernetes/resources.go
+++ b/romana/kubernetes/resources.go
@@ -215,7 +215,7 @@ func CreateDefaultPolicy(o KubeObject, l *kubeListener) {
 	}
 
 	if err2 := l.applyNetworkPolicy(desiredAction, *romanaPolicy); err2 != nil {
-		log.Printf("In CreateDefaultPolicy :: Error :: failed to apply %v to the policy %s \n", desiredAction, err)
+		log.Printf("In CreateDefaultPolicy :: Error :: failed to apply %v to the policy %s \n", desiredAction, err2)
 	}
 }
 

--- a/romana/kubernetes/resources.go
+++ b/romana/kubernetes/resources.go
@@ -32,10 +32,6 @@ const (
 // for terminating goroutines.
 type Done struct{}
 
-/*
-{"type":"ADDED","object":{"kind":"Namespace","apiVersion":"v1","metadata":{"name":"default","selfLink":"/api/v1/namespaces/default","uid":"d10db271-dc03-11e5-9c86-0213e1312dc5","resourceVersion":"6","creationTimestamp":"2016-02-25T21:07:45Z"},"spec":{"finalizers":["kubernetes"]},"status":{"phase":"Active"}}}
-*/
-
 // Event is a representation of a structure that we receive from kubernetes API.
 type Event struct {
 	Type   string     `json:"Type"`


### PR DESCRIPTION
This includes fixes from Stas so the listener supports v1.3. The format of NetworkPolicy definitions had changed.
Additional fixes for handling the annotation and minor changes to logging.