### PR TITLE
Enable proxy_arp per interface

### DIFF
--- a/cmd/romana_agent/main.go
+++ b/cmd/romana_agent/main.go
@@ -46,8 +46,6 @@ const (
 
 var (
 	kernelParameter = []string{
-		"/proc/sys/net/ipv4/conf/default/proxy_arp",
-		"/proc/sys/net/ipv4/conf/all/proxy_arp",
 		"/proc/sys/net/ipv4/ip_forward",
 	}
 )

--- a/cni/plugin.go
+++ b/cni/plugin.go
@@ -200,8 +200,7 @@ func CmdAdd(args *skel.CmdArgs) error {
 	// enable proxy_arp
 	err = ioutil.WriteFile(fmt.Sprintf("/proc/sys/net/ipv4/conf/%s/proxy_arp", hostIface.Name), []byte("1"), 0)
 	if err != nil {
-		// this is an optimization, so errors are logged, but don't result in failure
-		log.Infof("Failed to set proxy_arp for %s, err=(%s)", hostIface.Name, err)
+		return fmt.Errorf("Failed to set proxy_arp for %s, err=(%s)", hostIface.Name, err)
 	}
 
 	// set proxy_delay to zero

--- a/cni/plugin.go
+++ b/cni/plugin.go
@@ -197,6 +197,13 @@ func CmdAdd(args *skel.CmdArgs) error {
 		return fmt.Errorf("Failed to create veth interfaces in namespace %v, err=(%s)", netns, err)
 	}
 
+	// enable proxy_arp
+	err = ioutil.WriteFile(fmt.Sprintf("/proc/sys/net/ipv4/conf/%s/proxy_arp", hostIface.Name), []byte("1"), 0)
+	if err != nil {
+		// this is an optimization, so errors are logged, but don't result in failure
+		log.Infof("Failed to set proxy_arp for %s, err=(%s)", hostIface.Name, err)
+	}
+
 	// set proxy_delay to zero
 	err = ioutil.WriteFile(fmt.Sprintf("/proc/sys/net/ipv4/neigh/%s/proxy_delay", hostIface.Name), []byte("0"), 0)
 	if err != nil {


### PR DESCRIPTION
Hi, enabling `proxy_arp` for all interfaces isn't good idea, because in some configurations it can make loops in local network.
My patch fixes this problem, since enables `proxy_arp` option only for romana interfaces during the creation.